### PR TITLE
fix: implement back navigation on terms page

### DIFF
--- a/lib/presentation/onboarding/terms/terms_and_conditions_page.dart
+++ b/lib/presentation/onboarding/terms/terms_and_conditions_page.dart
@@ -14,6 +14,7 @@ import 'package:myafyahub/application/redux/view_models/app_state_view_model.dar
 import 'package:myafyahub/domain/core/entities/terms_and_conditions/terms_and_conditions.dart';
 import 'package:myafyahub/domain/core/value_objects/app_strings.dart';
 import 'package:myafyahub/presentation/core/theme/theme.dart';
+import 'package:myafyahub/presentation/core/widgets/app_bar/custom_app_bar.dart';
 import 'package:shared_themes/spaces.dart';
 import 'package:unicons/unicons.dart';
 
@@ -41,6 +42,7 @@ class _TermsAndConditionsPageState extends State<TermsAndConditionsPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      appBar: const CustomAppBar(title: portalTermsText),
       backgroundColor: Theme.of(context).backgroundColor,
       body: SafeArea(
         child: Padding(

--- a/test/widgets_tests/presentation/onboarding/terms_and_conditions_page_test.dart
+++ b/test/widgets_tests/presentation/onboarding/terms_and_conditions_page_test.dart
@@ -47,7 +47,7 @@ void main() {
         widget: const TermsAndConditionsPage(),
       );
 
-      expect(find.text(portalTermsText), findsOneWidget);
+      expect(find.text(portalTermsText), findsNWidgets(2));
       expect(find.text(readAndAcceptText), findsOneWidget);
       expect(find.text(acceptTermsText), findsOneWidget);
     });


### PR DESCRIPTION

![Screenshot_1646393001](https://user-images.githubusercontent.com/40171348/156755045-0d9ad97d-5825-4067-8a6c-d09851bb0c79.png)
- add app bar on terms page for back navigation on ios

Signed-off-by: Byron Kimani <byronkimani@gmail.com>