### PR TITLE
chore: upgrade CI images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
   run_tests_and_generate_coverage:
     resource_class: xlarge
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:2022.03.1-ndk
     steps:
       - install_packages
       - run:
@@ -106,7 +106,7 @@ jobs:
   deploy_to_internal_firebase_app_tester:
     resource_class: xlarge
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:2022.03.1-ndk
     steps:
       - install_packages
       - download_and_setup_keystore
@@ -127,7 +127,7 @@ jobs:
   deploy_to_play_store_alpha:
     resource_class: xlarge
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:2022.03.1-ndk
     steps:
       - install_packages
       - download_and_setup_keystore
@@ -162,7 +162,7 @@ jobs:
   deploy_to_play_store_beta:
     resource_class: xlarge
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:2022.03.1-ndk
     steps:
       - install_packages
       - download_and_setup_keystore
@@ -190,7 +190,7 @@ jobs:
   deploy_to_play_store_prod:
     resource_class: xlarge
     docker:
-      - image: circleci/android:api-30
+      - image: cimg/android:2022.03.1-ndk
     steps:
       - install_packages
       - download_and_setup_keystore
@@ -227,6 +227,7 @@ workflows:
            branches:
              only:
                - develop
+               - upgrade-ci-images
      - deploy_to_play_store_alpha:
          requires:
            - run_tests_and_generate_coverage

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -43,6 +43,7 @@ if (debugKeystorePropertiesFile.exists()) {
 
 android {
     compileSdkVersion 31
+    ndkVersion "22.1.7171670"
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'


### PR DESCRIPTION
- upgrade CircleCI image to cimg/android:2022.03.1-ndk
- set ndkVersion to "22.1.7171670" in the new CI image