### PR TITLE
chore: navigate to successful diary entry page upon success

### DIFF
--- a/lib/presentation/health_diary/widgets/share_diary_entry_dialog.dart
+++ b/lib/presentation/health_diary/widgets/share_diary_entry_dialog.dart
@@ -5,6 +5,7 @@ import 'package:app_wrapper/app_wrapper.dart';
 import 'package:async_redux/async_redux.dart';
 import 'package:myafyahub/application/redux/actions/share_diary_entry_action.dart';
 import 'package:myafyahub/presentation/health_diary/widgets/mood_selection/mood_symptom_widget.dart';
+import 'package:myafyahub/presentation/router/routes.dart';
 import 'package:shared_themes/spaces.dart';
 
 import 'package:myafyahub/application/redux/flags/flags.dart';
@@ -114,11 +115,9 @@ class _ShareDiaryEntryDialogState extends State<ShareDiaryEntryDialog> {
                               canShareEntireDiaryEntry: canShareEntireEntry,
                               client: AppWrapperBase.of(context)!.graphQLClient,
                               onSuccess: () {
-                                Navigator.of(context).pop();
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                    content: Text(diaryEntrySharedSuccessfully),
-                                  ),
+                                Navigator.popAndPushNamed(
+                                  context,
+                                  AppRoutes.successfulEntryPage,
                                 );
                               },
                               onFailure: () {

--- a/test/widgets_tests/presentation/health_diary/share_diary_entry_dialog_test.dart
+++ b/test/widgets_tests/presentation/health_diary/share_diary_entry_dialog_test.dart
@@ -9,6 +9,7 @@ import 'package:myafyahub/application/redux/states/app_state.dart';
 import 'package:myafyahub/domain/core/entities/health_diary/health_diary_entry.dart';
 import 'package:myafyahub/domain/core/value_objects/app_widget_keys.dart';
 import 'package:myafyahub/presentation/health_diary/widgets/share_diary_entry_dialog.dart';
+import 'package:myafyahub/presentation/health_diary/widgets/successful_diary_entry_page.dart';
 
 import '../../../mocks.dart';
 import '../../../test_helpers.dart';
@@ -124,7 +125,7 @@ void main() {
       await tester.tap(find.byKey(shareDiaryEntryKey));
       await tester.pumpAndSettle();
 
-      expect(find.byType(SnackBar), findsOneWidget);
+      expect(find.byType(SuccessfulDiaryEntryPage), findsOneWidget);
     });
 
     testWidgets('share displays error snackbar correctly',


### PR DESCRIPTION
- navigate to successful diary entry page on success
![Screenshot_1649928253](https://user-images.githubusercontent.com/40171348/163356716-e26e3186-5b10-4bf7-8570-1a079f7bd870.png)

Signed-off-by: Byron Kimani <byronkimani@gmail.com>