### PR TITLE
fix: show surveys carousel only when available

### DIFF
--- a/lib/presentation/home/widgets/survey_carousel.dart
+++ b/lib/presentation/home/widgets/survey_carousel.dart
@@ -33,6 +33,9 @@ class SurveyCarousel extends StatelessWidget {
       },
       builder: (BuildContext context, AppStateViewModel state) {
         final MiscState miscState = state.appState.miscState!;
+        if (miscState.availableSurveysList?.isEmpty ?? true) {
+          return const SizedBox();
+        }
         return Column(
           mainAxisSize: MainAxisSize.min,
           crossAxisAlignment: CrossAxisAlignment.start,


### PR DESCRIPTION
- show surveys carousel only when available
![Screenshot_1653470988](https://user-images.githubusercontent.com/40171348/170230622-aadec930-15fd-40af-ab6a-bcc0dceb19d5.png)

Signed-off-by: Byron Kimani <byronkimani@gmail.com>