### PR TITLE
fix: error occurring on medical data page upon retry

### DIFF
--- a/lib/presentation/profile/medical_data/pages/medical_data_page.dart
+++ b/lib/presentation/profile/medical_data/pages/medical_data_page.dart
@@ -107,7 +107,7 @@ class _MedicalDataPageState extends State<MedicalDataPage> {
                     StoreProvider.dispatch(
                       context,
                       FetchMedicalDataAction(
-                        httpClient: AppWrapperBase.of(context)!.graphQLClient,
+                        httpClient: client,
                       ),
                     );
                   },

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -14,7 +14,7 @@ packages:
       name: afya_moja_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "0.1.2"
   analyzer:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ environment:
   sdk: ">=2.14.4 <3.0.0"
 
 dependencies:
-  afya_moja_core: ^0.1.1
+  afya_moja_core: ^0.1.2
   app_wrapper: ^0.1.35
   async_redux: ^13.3.1
   collection: ^1.15.0


### PR DESCRIPTION
- use the correct graphql endpoint when re-fetching medical data
- upgrade core to change content avatars from hardcoded image
![Screenshot_1655453089](https://user-images.githubusercontent.com/40171348/174255269-b5a3f477-22a1-4ab3-b233-29370f7b8f74.png)

Signed-off-by: Byron Kimani <byronkimani@gmail.com>